### PR TITLE
ICMSLST-1285 Use Django's django.conf.settings module

### DIFF
--- a/mail/apps.py
+++ b/mail/apps.py
@@ -1,7 +1,6 @@
 from django.apps import AppConfig
+from django.conf import settings
 from django.db.models.signals import post_migrate
-
-from conf.settings import BACKGROUND_TASK_ENABLED, INBOX_POLL_INTERVAL, LITE_LICENCE_DATA_POLL_INTERVAL
 
 
 class MailConfig(AppConfig):
@@ -22,9 +21,9 @@ class MailConfig(AppConfig):
         Task.objects.filter(queue=MANAGE_INBOX_TASK_QUEUE).delete()
         Task.objects.filter(queue=LICENCE_DATA_TASK_QUEUE).delete()
 
-        if BACKGROUND_TASK_ENABLED:
-            manage_inbox(repeat=INBOX_POLL_INTERVAL, repeat_until=None)  # noqa
-            send_licence_data_to_hmrc(repeat=LITE_LICENCE_DATA_POLL_INTERVAL, repeat_until=None)  # noqa
+        if settings.BACKGROUND_TASK_ENABLED:
+            manage_inbox(repeat=settings.INBOX_POLL_INTERVAL, repeat_until=None)  # noqa
+            send_licence_data_to_hmrc(repeat=settings.LITE_LICENCE_DATA_POLL_INTERVAL, repeat_until=None)  # noqa
 
             usage_updates_not_sent_to_lite = UsageData.objects.filter(has_lite_data=True, lite_sent_at__isnull=True)
             for obj in usage_updates_not_sent_to_lite:

--- a/mail/libraries/data_processors.py
+++ b/mail/libraries/data_processors.py
@@ -1,11 +1,11 @@
 import logging
 import threading
 
+from django.conf import settings
 from django.db import transaction
 from django.utils import timezone
 from rest_framework.exceptions import ValidationError
 
-from conf.settings import SYSTEM_INSTANCE_UUID, LOCK_INTERVAL
 from mail.enums import ExtractTypeEnum, ReceptionStatusEnum
 from mail.libraries.builders import build_request_mail_message_dto, build_reply_mail_message_dto
 from mail.libraries.data_converters import (
@@ -150,13 +150,15 @@ def lock_db_for_sending_transaction(mail: Mail) -> bool:
     previous_locking_process_id = mail.currently_processed_by
     if (
         not previous_locking_process_id
-        or (timezone.now() - mail.currently_processing_at).total_seconds() > LOCK_INTERVAL
+        or (timezone.now() - mail.currently_processing_at).total_seconds() > settings.LOCK_INTERVAL
     ):
         with transaction.atomic():
             _mail = Mail.objects.select_for_update().get(id=mail.id)
             if _mail.currently_processed_by != previous_locking_process_id:
                 return False
-            _mail.currently_processed_by = str(SYSTEM_INSTANCE_UUID) + "-" + str(threading.currentThread().ident)
+            _mail.currently_processed_by = (
+                str(settings.SYSTEM_INSTANCE_UUID) + "-" + str(threading.currentThread().ident)
+            )
             _mail.set_locking_time()
             _mail.save()
 

--- a/mail/libraries/routing_controller.py
+++ b/mail/libraries/routing_controller.py
@@ -7,7 +7,6 @@ from itertools import islice
 from django.conf import settings
 from django.utils import timezone
 
-from conf.settings import SPIRE_ADDRESS
 from mail.enums import ReceptionStatusEnum, SourceEnum, ExtractTypeEnum, MailReadStatuses
 from mail.libraries.builders import build_email_message
 from mail.libraries.data_processors import (
@@ -189,7 +188,7 @@ def _collect_and_send(mail: Mail):
         else:
             update_mail(mail, message_to_send_dto)
 
-        if message_to_send_dto.receiver == SPIRE_ADDRESS and mail.extract_type == ExtractTypeEnum.LICENCE_DATA:
+        if message_to_send_dto.receiver == settings.SPIRE_ADDRESS and mail.extract_type == ExtractTypeEnum.LICENCE_DATA:
             # Pick up any LITE licence updates once we send a licence update reply email to SPIRE
             # so LITE does not get locked out of the queue by SPIRE
             send_licence_data_to_hmrc(schedule=0)  # noqa

--- a/mail/requests.py
+++ b/mail/requests.py
@@ -7,15 +7,10 @@ from json import dumps as serialize
 import logging
 
 import requests  # noqa
+from django.conf import settings
 from django.core.cache import cache
 from mohawk import Sender
 from mohawk.exc import AlreadyProcessed
-
-from conf.settings import (
-    HAWK_AUTHENTICATION_ENABLED,
-    HAWK_RECEIVER_NONCE_EXPIRY_SECONDS,
-    HAWK_CREDENTIALS,
-)
 
 
 class RequestException(Exception):
@@ -42,7 +37,7 @@ def make_request(method, url, data=None, headers=None, hawk_credentials=None, ti
     headers = headers or {}  # If no headers are supplied, default to an empty dictionary
     headers["content-type"] = "application/json"
 
-    if HAWK_AUTHENTICATION_ENABLED:
+    if settings.HAWK_AUTHENTICATION_ENABLED:
         if not hawk_credentials:
             raise RequestException("'hawk_credentials' must be specified when 'HAWK_AUTHENTICATION_ENABLED' is 'True'")
 
@@ -72,7 +67,7 @@ def send_request(method, url, data=None, headers=None, timeout=None):
 
 def get_hawk_sender(method, url, data, credentials):
     content = serialize(data) if data else data
-    credentials = HAWK_CREDENTIALS.get(credentials)
+    credentials = settings.HAWK_CREDENTIALS.get(credentials)
 
     return Sender(credentials, url, method, content=content, content_type="application/json", seen_nonce=_seen_nonce)
 
@@ -103,7 +98,7 @@ def _seen_nonce(access_key_id, nonce, timestamp):
     cache_key = f"hawk:{access_key_id}:{nonce}"
 
     # cache.add only adds key if it isn't present
-    seen_cache_key = not cache.add(cache_key, True, timeout=HAWK_RECEIVER_NONCE_EXPIRY_SECONDS)
+    seen_cache_key = not cache.add(cache_key, True, timeout=settings.HAWK_RECEIVER_NONCE_EXPIRY_SECONDS)
 
     if seen_cache_key:
         raise AlreadyProcessed(f"Already seen nonce {nonce}")

--- a/mail/servers.py
+++ b/mail/servers.py
@@ -2,18 +2,18 @@ import logging
 import poplib
 import smtplib
 
-from conf.settings import EMAIL_PASSWORD, EMAIL_HOSTNAME, EMAIL_USER, EMAIL_POP3_PORT, EMAIL_SMTP_PORT, EMAIL_USE_TLS
+from django.conf import settings
 
 
 class MailServer(object):
     def __init__(
         self,
-        hostname: str = EMAIL_HOSTNAME,
-        user: str = EMAIL_USER,
-        password: str = EMAIL_PASSWORD,
-        pop3_port: int = EMAIL_POP3_PORT,
-        smtp_port: int = EMAIL_SMTP_PORT,
-        use_tls: bool = EMAIL_USE_TLS,
+        hostname: str = settings.EMAIL_HOSTNAME,
+        user: str = settings.EMAIL_USER,
+        password: str = settings.EMAIL_PASSWORD,
+        pop3_port: int = settings.EMAIL_POP3_PORT,
+        smtp_port: int = settings.EMAIL_SMTP_PORT,
+        use_tls: bool = settings.EMAIL_USE_TLS,
     ):
         self.smtp_port = smtp_port
         self.pop3_port = pop3_port

--- a/mail/tasks.py
+++ b/mail/tasks.py
@@ -7,20 +7,11 @@ from email.mime.text import MIMEText
 
 from background_task import background
 from background_task.models import Task
+from django.conf import settings
 from django.db import transaction
 from django.utils import timezone
 from rest_framework.status import HTTP_207_MULTI_STATUS, HTTP_208_ALREADY_REPORTED
 
-from conf.settings import (
-    EMAIL_USER,
-    NOTIFY_USERS,
-)
-from conf.settings import (
-    LITE_API_URL,
-    HAWK_LITE_HMRC_INTEGRATION_CREDENTIALS,
-    LITE_API_REQUEST_TIMEOUT,
-    MAX_ATTEMPTS,
-)
 from mail.enums import ReceptionStatusEnum, ReplyStatusEnum
 from mail.libraries.builders import build_licence_data_mail
 from mail.libraries.data_processors import build_request_mail_message_dto
@@ -64,10 +55,10 @@ def send_licence_usage_figures_to_lite_api(lite_usage_data_id):
     try:
         build_lite_payload(lite_usage_data)
         response = put(
-            f"{LITE_API_URL}/licences/hmrc-integration/",
+            f"{settings.LITE_API_URL}/licences/hmrc-integration/",
             lite_usage_data.lite_payload,
-            hawk_credentials=HAWK_LITE_HMRC_INTEGRATION_CREDENTIALS,
-            timeout=LITE_API_REQUEST_TIMEOUT,
+            hawk_credentials=settings.HAWK_LITE_HMRC_INTEGRATION_CREDENTIALS,
+            timeout=settings.LITE_API_REQUEST_TIMEOUT,
         )
     except Exception as exc:  # noqa
         _handle_exception(
@@ -156,7 +147,9 @@ def schedule_max_tried_task_as_new_task(lite_usage_data_id):
     Abstracted from 'send_licence_usage_figures_to_lite_api' to enable unit testing of a recursive operation
     """
 
-    logging.warning(f"Maximum attempts of {MAX_ATTEMPTS} for LITE UsageData [{lite_usage_data_id}] has been reached")
+    logging.warning(
+        f"Maximum attempts of {settings.MAX_ATTEMPTS} for LITE UsageData [{lite_usage_data_id}] has been reached"
+    )
 
     schedule_datetime = timezone.now() + timedelta(seconds=TASK_BACK_OFF)
     logging.info(f"Scheduling new task for LITE UsageData [{lite_usage_data_id}] to commence at [{schedule_datetime}]")
@@ -178,7 +171,7 @@ def _handle_exception(message, lite_usage_data_id):
         # HMRC Integration tasks need to be resilient and keep retrying post-failure indefinitely.
         # This logic will make MAX_ATTEMPTS attempts to send licence changes according to the Django Background Task
         # Runner scheduling, then wait TASK_BACK_OFF seconds before starting the process again.
-        if current_attempt >= MAX_ATTEMPTS:
+        if current_attempt >= settings.MAX_ATTEMPTS:
             schedule_max_tried_task_as_new_task(lite_usage_data_id)
 
     # Raise an exception
@@ -267,8 +260,8 @@ def notify_users_of_rejected_mail(mail_id, mail_response_date):
 
     try:
         multipart_msg = MIMEMultipart()
-        multipart_msg["From"] = EMAIL_USER
-        multipart_msg["To"] = ",".join(NOTIFY_USERS)
+        multipart_msg["From"] = settings.EMAIL_USER
+        multipart_msg["To"] = ",".join(settings.NOTIFY_USERS)
         multipart_msg["Subject"] = "Mail rejected"
         body = MIMEText(f"Mail [{mail_id}] received at [{mail_response_date}] was rejected")
         multipart_msg.attach(body)

--- a/mail/tests/test_data_processors.py
+++ b/mail/tests/test_data_processors.py
@@ -1,10 +1,10 @@
 import logging
 
 from datetime import datetime
+from django.conf import settings
 from django.test import tag
 from rest_framework.exceptions import ValidationError
 
-from conf.settings import SPIRE_ADDRESS, HMRC_ADDRESS, EMAIL_USER
 from mail.enums import ExtractTypeEnum, ReceptionStatusEnum, SourceEnum
 from mail.libraries.builders import build_sent_filename, build_sent_file_data
 from mail.libraries.data_processors import (
@@ -43,8 +43,8 @@ class TestDataProcessors(LiteHMRCTestClient):
     def test_mail_data_serialized_successfully(self):
         email_message_dto = EmailMessageDto(
             run_number=self.source_run_number,
-            sender=HMRC_ADDRESS,
-            receiver=SPIRE_ADDRESS,
+            sender=settings.HMRC_ADDRESS,
+            receiver=settings.SPIRE_ADDRESS,
             date="Mon, 17 May 2021 14:20:18 +0100",
             body="body",
             subject=self.licence_usage_file_name,
@@ -69,10 +69,10 @@ class TestDataProcessors(LiteHMRCTestClient):
         dto = to_email_message_dto_from(self.mail)
 
         self.assertEqual(dto.run_number, self.usage_data.spire_run_number)
-        self.assertEqual(dto.sender, HMRC_ADDRESS)
+        self.assertEqual(dto.sender, settings.HMRC_ADDRESS)
         self.assertEqual("ILBDOTI_live_CHIEF_licenceReply_49543_201902080025", self.mail.edi_filename)
         self.assertEqual("ILBDOTI_live_CHIEF_licenceReply_49543_201902080025", self.mail.edi_filename)
-        self.assertEqual(dto.receiver, SPIRE_ADDRESS)
+        self.assertEqual(dto.receiver, settings.SPIRE_ADDRESS)
         self.assertTrue(isinstance(dto.date, datetime))
         self.assertEqual(dto.body, None)
         self.assertEqual(dto.raw_data, None)
@@ -84,8 +84,8 @@ class TestDataProcessors(LiteHMRCTestClient):
 
         email_message_dto = EmailMessageDto(
             run_number=self.source_run_number + 1,
-            sender=HMRC_ADDRESS,
-            receiver=SPIRE_ADDRESS,
+            sender=settings.HMRC_ADDRESS,
+            receiver=settings.SPIRE_ADDRESS,
             date="Mon, 17 May 2021 14:20:18 +0100",
             body="body",
             subject=self.licence_data_reply_name,
@@ -104,8 +104,8 @@ class TestDataProcessors(LiteHMRCTestClient):
         self.mail.save()
         email_message_dto = EmailMessageDto(
             run_number=self.source_run_number + 1,
-            sender=SPIRE_ADDRESS,
-            receiver=HMRC_ADDRESS,
+            sender=settings.SPIRE_ADDRESS,
+            receiver=settings.HMRC_ADDRESS,
             date="Mon, 17 May 2021 14:20:18 +0100",
             body="body",
             subject=self.usage_data_reply_name,
@@ -133,8 +133,8 @@ class TestDataProcessors(LiteHMRCTestClient):
 
         email_message_dto = EmailMessageDto(
             run_number=self.hmrc_run_number,
-            sender=HMRC_ADDRESS,
-            receiver=EMAIL_USER,
+            sender=settings.HMRC_ADDRESS,
+            receiver=settings.EMAIL_USER,
             date="Mon, 17 May 2021 14:20:18 +0100",
             body="body",
             subject=self.licence_data_reply_name,

--- a/mail/tests/test_end_to_end.py
+++ b/mail/tests/test_end_to_end.py
@@ -1,8 +1,7 @@
 from urllib.parse import quote
 
-from conf.settings import MAILHOG_URL
-
 import requests
+from django.conf import settings
 from django.urls import reverse
 
 from mail.tests.libraries.client import LiteHMRCTestClient
@@ -10,15 +9,15 @@ from mail.tests.libraries.client import LiteHMRCTestClient
 
 class EndToEndTests(LiteHMRCTestClient):
     def clear_stmp_mailbox(self):
-        response = requests.get(f"{MAILHOG_URL}/api/v2/messages")
+        response = requests.get(f"{settings.MAILHOG_URL}/api/v2/messages")
         print(response)
         for message in response.json()["items"]:
             id = message["ID"]
             print(f"delete {id}")
-            requests.delete(f"{MAILHOG_URL}/api/v1/messages/{id}")
+            requests.delete(f"{settings.MAILHOG_URL}/api/v1/messages/{id}")
 
     def get_smtp_body(self):
-        response = requests.get(f"{MAILHOG_URL}/api/v2/messages")
+        response = requests.get(f"{settings.MAILHOG_URL}/api/v2/messages")
         print(response)
         return response.json()["items"][0]["MIME"]["Parts"][1]["Body"]
 

--- a/mail/tests/test_helpers.py
+++ b/mail/tests/test_helpers.py
@@ -1,9 +1,9 @@
 import logging
 
+from django.conf import settings
 from django.test import tag
 from parameterized import parameterized
 
-from conf.settings import SPIRE_ADDRESS
 from mail.enums import ExtractTypeEnum, ReceptionStatusEnum, SourceEnum, UnitMapping
 from mail.libraries.helpers import (
     convert_sender_to_source,
@@ -21,11 +21,11 @@ from mail.tests.libraries.client import LiteHMRCTestClient
 
 
 class HelpersTests(LiteHMRCTestClient):
-    @parameterized.expand([[SPIRE_ADDRESS, SourceEnum.SPIRE], ["LITE", "LITE"]])
+    @parameterized.expand([[settings.SPIRE_ADDRESS, SourceEnum.SPIRE], ["LITE", "LITE"]])
     def test_convert_sender_to_source(self, sender, source):
         self.assertEqual(convert_sender_to_source(sender), source)
 
-    @parameterized.expand([[SPIRE_ADDRESS, SourceEnum.SPIRE], ["LITE", "LITE"]])
+    @parameterized.expand([[settings.SPIRE_ADDRESS, SourceEnum.SPIRE], ["LITE", "LITE"]])
     def test_convert_source_to_sender(self, sender, source):
         self.assertEqual(convert_source_to_sender(source), sender)
 

--- a/mail/tests/test_retreive_and_process_multiple_emails.py
+++ b/mail/tests/test_retreive_and_process_multiple_emails.py
@@ -1,6 +1,6 @@
+from django.conf import settings
 from django.test import tag
 
-from conf.settings import HMRC_ADDRESS, SPIRE_ADDRESS, EMAIL_USER
 from mail.enums import ExtractTypeEnum, ReceptionStatusEnum, SourceEnum
 from mail.libraries.data_processors import serialize_email_message
 from mail.libraries.email_message_dto import EmailMessageDto
@@ -14,8 +14,8 @@ class MultipleEmailRetrievalTests(LiteHMRCTestClient):
         super().setUp()
         self.dto_1 = EmailMessageDto(
             run_number=49543,
-            sender=HMRC_ADDRESS,
-            receiver=EMAIL_USER,
+            sender=settings.HMRC_ADDRESS,
+            receiver=settings.EMAIL_USER,
             date="Mon, 17 May 2021 14:20:18 +0100",
             body="lite licence reply",
             subject="ILBDOTI_live_CHIEF_licenceReply_49543_201901130300",
@@ -24,8 +24,8 @@ class MultipleEmailRetrievalTests(LiteHMRCTestClient):
         )
         self.dto_2 = EmailMessageDto(
             run_number=17,
-            sender=SPIRE_ADDRESS,
-            receiver=EMAIL_USER,
+            sender=settings.SPIRE_ADDRESS,
+            receiver=settings.EMAIL_USER,
             date="Mon, 17 May 2021 14:20:18 +0100",
             body="spire licence update",
             subject="ILBDOTI_live_CHIEF_licenceData_17_201901130300",
@@ -34,8 +34,8 @@ class MultipleEmailRetrievalTests(LiteHMRCTestClient):
         )
         self.dto_3 = EmailMessageDto(
             run_number=49542,
-            sender=HMRC_ADDRESS,
-            receiver=EMAIL_USER,
+            sender=settings.HMRC_ADDRESS,
+            receiver=settings.EMAIL_USER,
             date="Mon, 17 May 2021 14:20:18 +0100",
             body="spire licence reply",
             subject="ILBDOTI_live_CHIEF_licenceReply_49542_201901130300",

--- a/mail/tests/test_send_lite_licence_updates_task.py
+++ b/mail/tests/test_send_lite_licence_updates_task.py
@@ -1,6 +1,6 @@
 from unittest import mock
 
-from django.test import tag
+from django.test import override_settings, tag
 
 from mail.enums import ReceptionStatusEnum
 from mail.models import LicencePayload, Mail
@@ -9,7 +9,7 @@ from mail.tests.libraries.client import LiteHMRCTestClient
 from mail.libraries.lite_to_edifact_converter import EdifactValidationError
 
 
-@mock.patch("mail.apps.BACKGROUND_TASK_ENABLED", False)  # Disable task from being run on app initialization
+@override_settings(BACKGROUND_TASK_ENABLED=False)  # Disable task from being run on app initialization
 class TaskTests(LiteHMRCTestClient):
     @tag("missed-timing")
     @mock.patch("mail.tasks.send")


### PR DESCRIPTION
Instead of import settings from conf.settings, we can use Django's settings
feature which will proxy things from the DJANGO_SETTINGS_MODULE module.
This pattern allows us to override settings in tests, and to point at a
different DJANGO_SETTINGS_MODULE without having to change the imports.