### PR TITLE
ICMSLST-1285 Define SMTP settings with the EMAIL_URL variable

### DIFF
--- a/conf/settings.py
+++ b/conf/settings.py
@@ -138,6 +138,11 @@ SPIRE_INCOMING_EMAIL_ADDRESS = env("SPIRE_INCOMING_EMAIL_ADDRESS", default="spir
 SPIRE_FROM_ADDRESS = env("SPIRE_FROM_ADDRESS", default="spire@example.com")
 HMRC_TO_DIT_REPLY_ADDRESS = env("HMRC_TO_DIT_REPLY_ADDRESS", default="hmrctodit@example.com")
 
+# This sets EMAIL_FILE_PATH, EMAIL_HOST_USER, EMAIL_HOST_PASSWORD, EMAIL_HOST,
+# EMAIL_PORT, EMAIL_BACKEND and optionally sets EMAIL_USE_TLS.
+_email_url = env.email_url("EMAIL_URL", default="smtp://localhost")
+vars().update(_email_url)
+
 EMAIL_PASSWORD = env("EMAIL_PASSWORD")
 EMAIL_HOSTNAME = env("EMAIL_HOSTNAME")
 EMAIL_USER = env("EMAIL_USER")


### PR DESCRIPTION
With EMAIL_URL=smtp://localhost this configures several of Django's
email-related settings. But use EMAIL_URL=smtps://localhost and it
will also define EMAIL_USE_TLS=True.