### PR TITLE
Adding CODEOWNERS file

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,2 @@
+# The ICMS team maintain icms-hmrc
+* @uktrade/icms


### PR DESCRIPTION
This is to make it easier from a department-level to keep track of who owns each repo