### PR TITLE
ICMSLST-2794 Disable celery schedule in production environment.

### DIFF
--- a/mail/management/commands/dev_fake_licence_reply.py
+++ b/mail/management/commands/dev_fake_licence_reply.py
@@ -43,7 +43,7 @@ class Command(BaseCommand):
     def handle(self, outcome: FakeChiefLicenceReplyEnum, *args, **options):
         self.stdout.write(f"Desired outcome: {outcome}")
 
-        if utils.get_app_env() == "production":
+        if utils.is_production_environment():
             self.stdout.write("This command is only for development environments")
             return
 

--- a/mail/tasks.py
+++ b/mail/tasks.py
@@ -33,7 +33,7 @@ logger = logging.getLogger(__name__)
 def dev_process_hmrc_licence_data() -> None:
     """Run all tasks in one task for speed when in a development environment."""
 
-    if utils.get_app_env() == "production":
+    if utils.is_production_environment():
         logger.warning("This command is only for development environments")
         return
 
@@ -117,7 +117,7 @@ def send_licence_data_to_hmrc() -> None:
 
 @celery_app.task(name="icms:fake_licence_reply")
 def fake_licence_reply():
-    if utils.get_app_env() == "production":
+    if utils.is_production_environment():
         logger.warning("This command is only for development environments")
         return
 

--- a/mail/utils/__init__.py
+++ b/mail/utils/__init__.py
@@ -6,3 +6,7 @@ def get_app_env() -> str:
         raise ValueError("APP_ENV has not been set")
 
     return settings.APP_ENV
+
+
+def is_production_environment() -> bool:
+    return get_app_env() == "production"


### PR DESCRIPTION
Changes:
  - Add utility function for checking for production env.
  - Disable prod schedule so that we can deploy the prod app with real email connection details to testing email reading / sending.