### PR TITLE
ICMSLST-2963 Add ability to test icms-hmrc / icms connections.

### DIFF
--- a/mail/management/commands/check_icms_connection.py
+++ b/mail/management/commands/check_icms_connection.py
@@ -1,0 +1,39 @@
+import json
+from urllib.parse import urljoin
+
+import requests
+from django.conf import settings
+from django.core.management.base import BaseCommand, CommandError
+
+from mail import requests as mail_requests
+
+
+# To run: make manage args="check_icms_connection"
+class Command(BaseCommand):
+    help = """Test ICMS-HMRC can send a request to ICMS server."""
+
+    def handle(self, *args, **options):
+        self.stdout.write("Checking ICMS connection.")
+
+        url = urljoin(settings.ICMS_API_URL, "chief/check-icms-connection/")
+        data = {"foo": "bar"}
+
+        response: requests.Response = mail_requests.post(
+            url,
+            data,
+            hawk_credentials=settings.ICMS_API_ID,
+            timeout=settings.ICMS_API_REQUEST_TIMEOUT,
+        )
+
+        try:
+            response.raise_for_status()
+        except requests.HTTPError as e:
+            self.stderr.write(str(response.content))
+            raise e
+
+        response_content = json.loads(response.content.decode("utf-8"))
+
+        if response_content != {"bar": "foo"}:
+            raise CommandError(f"Invalid response from ICMS: {response_content}")
+
+        self.stdout.write("ICMS-HMRC can communicate with ICMS using mohawk.", self.style.SUCCESS)

--- a/mail/urls.py
+++ b/mail/urls.py
@@ -6,4 +6,9 @@ app_name = "mail"
 
 urlpatterns = [
     path("update-licence/", views.LicenceDataIngestView.as_view(), name="update_licence"),
+    path(
+        "check-icms-hmrc-connection/",
+        views.CheckICMSHMRCConnectionView.as_view(),
+        name="check_icms_hmrc_connection",
+    ),
 ]

--- a/mail/views.py
+++ b/mail/views.py
@@ -76,3 +76,18 @@ def get_serializer_cls(app_type: str, action: str) -> Type["Serializer"]:
             return serializers.SanctionLicenceDataSerializer
         case _:
             raise ValueError(f"Unsupported app type: ({app_type})")
+
+
+class CheckICMSHMRCConnectionView(APIView):
+    """View used by ICMS to test connection to ICMS-HMRC"""
+
+    authentication_classes = (HawkOnlyAuthentication,)
+    http_method_names = ["post"]
+
+    def post(self, request):
+        if request.data != {"foo": "bar"}:
+            error_msg = f"Invalid request data: {request.data}"
+
+            return JsonResponse(status=status.HTTP_400_BAD_REQUEST, data={"errors": error_msg})
+
+        return JsonResponse(status=status.HTTP_200_OK, data={"bar": "foo"})


### PR DESCRIPTION
Changes:
  - Add endpoint that ICMS uses to test it can communicate with ICMS-HMRC.
  - Add management command to test ICMS-HMRC can commumicate with ICMS.