### PR TITLE
Update order by to show most recent on top when viewing in admin site.

### DIFF
--- a/mail/admin.py
+++ b/mail/admin.py
@@ -13,6 +13,8 @@ class LicencePayloadInline(admin.TabularInline):
 
 
 class LicenceDataAdmin(admin.ModelAdmin):
+    ordering = ["-pk"]
+
     def get_queryset(self, request):
         qs = super().get_queryset(request)
 
@@ -28,6 +30,7 @@ class LicenceDataAdmin(admin.ModelAdmin):
 
 class MailAdmin(admin.ModelAdmin):
     list_display = ["pk", "edi_filename", "status", "extract_type", "sent_at", "response_date"]
+    ordering = ["-created_at"]
 
     def has_change_permission(self, request, obj=None):
         """Prevent modification of Mail records to minimise the risk of introducing data bugs.
@@ -38,6 +41,10 @@ class MailAdmin(admin.ModelAdmin):
         return False
 
 
+class LicencePayloadAdmin(admin.ModelAdmin):
+    ordering = ["-received_at"]
+
+
 admin.site.register(LicenceData, LicenceDataAdmin)
 admin.site.register(Mail, MailAdmin)
-admin.site.register(LicencePayload)
+admin.site.register(LicencePayload, LicencePayloadAdmin)

--- a/mail/chief/licence_data/processor.py
+++ b/mail/chief/licence_data/processor.py
@@ -26,7 +26,8 @@ logger = logging.getLogger(__name__)
 
 
 def create_licence_data_mail(licences: "QuerySet[LicencePayload]", source: SourceEnum) -> Mail:
-    last_licence_data = LicenceData.objects.last()
+    # Copied the order_by from the model so that this logic is preserved
+    last_licence_data = LicenceData.objects.order_by("mail__created_at").last()
     run_number = last_licence_data.hmrc_run_number + 1 if last_licence_data else 1
     when = timezone.now()
 

--- a/mail/models.py
+++ b/mail/models.py
@@ -22,6 +22,8 @@ class LicencePayload(models.Model):
 
     class Meta:
         unique_together = [["icms_id", "action"]]
+
+        # NOTE: Do not change this as the app code is flaky and requires this ordering
         ordering = ["received_at"]
 
     def __str__(self):
@@ -46,6 +48,7 @@ class LicenceData(models.Model):
     )
 
     class Meta:
+        # NOTE: Do not change this as the app code is flaky and requires this ordering
         ordering = ["mail__created_at"]
 
 
@@ -77,6 +80,7 @@ class Mail(models.Model):
 
     class Meta:
         db_table = "mail"
+        # NOTE: Do not change this as the app code is flaky and requires this ordering
         ordering = ["created_at"]
 
     def __str__(self):


### PR DESCRIPTION
I'm a lot happier now the ordering is fixed in the admin and it doesn't break the code that fetches the next hmrc run number:
![image](https://github.com/user-attachments/assets/3040d61c-60ab-44f3-9ee3-cd559aa84196)
I seeded the db with 123 rows and it correctly picked up 124 as the next run number.