### PR TITLE
ICMSLST-3022 Allow individual importers with EORI of GBPR

### DIFF
--- a/conf/urls.py
+++ b/conf/urls.py
@@ -13,6 +13,7 @@ Including another URLconf
     1. Import the include() function: from django.urls import include, path
     2. Add a URL to urlpatterns:  path('blog/', include('blog.urls'))
 """
+
 from django.contrib import admin
 from django.urls import include, path
 

--- a/mail/auth.py
+++ b/mail/auth.py
@@ -15,7 +15,7 @@ class Authenticator(Protocol):
     tenant_id: str
 
     def authenticate(self, connection: poplib.POP3_SSL):
-        ...
+        ...  # fmt: skip
 
 
 class ModernAuthentication:

--- a/mail/chief/licence_data/processor.py
+++ b/mail/chief/licence_data/processor.py
@@ -152,9 +152,12 @@ def generate_lines_for_icms_licence(licence: LicencePayload) -> Iterable[types._
     if licence.action in [LicenceActionEnum.INSERT, LicenceActionEnum.REPLACE]:
         trader = payload.get("organisation")
         trader_address = trader.get("address")
+        eori = trader.get("eori_number")
+        turn = "PR" if eori == "GBPR" else None
 
         yield types.Trader(
-            rpa_trader_id=trader.get("eori_number"),
+            rpa_trader_id=None if turn else eori,
+            turn=turn,
             start_date=get_date_field(trader, "start_date"),
             end_date=get_date_field(trader, "end_date"),
             name=trader.get("name"),

--- a/mail/tests/chief/licence_data/test_processor.py
+++ b/mail/tests/chief/licence_data/test_processor.py
@@ -274,6 +274,68 @@ class TestBuildICMSLicenceDataFASIL(testcases.TestCase):
         self.assertEqual(expected_content, file_content)
 
 
+class TestBuildICMSLicenceDataFASILIndividualImporter(testcases.TestCase):
+    def setUp(self) -> None:
+        org_data = {
+            "eori_number": "GBPR",
+            "name": "SIL Organisation",
+            "address": {
+                "line_1": "line_1",
+                "line_2": "line_2",
+                "line_3": "line_3",
+                "line_4": "",
+                "line_5": "",
+                "postcode": "S227ZZ",
+            },
+        }
+
+        restrictions = "Sample restrictions"
+
+        goods = [
+            {
+                "description": "Sample goods description 1",
+                "quantity": 1,
+                "controlled_by": "Q",
+                "unit": 30,
+            }
+        ]
+
+        LicencePayload.objects.create(
+            icms_id="4277dd90-7ac0-4f48-b228-94c4a2fc61b2",
+            reference="IMA/2022/00003",
+            action=LicenceActionEnum.INSERT,
+            data={
+                "type": LicenceTypeEnum.IMPORT_SIL.value,
+                "reference": "IMA/2022/00003",
+                "licence_reference": "GBSIL3333333H",
+                "start_date": "2022-06-29",
+                "end_date": "2024-12-29",
+                "organisation": org_data,
+                "country_code": "US",
+                "restrictions": restrictions,
+                "goods": goods,
+            },
+        )
+
+        self.test_file = Path("mail/tests/files/icms/licence_data_files/fa_sil_individual_importer")
+        self.assertTrue(self.test_file.is_file())
+
+    def test_generate_licence_data_file(self):
+        licences = LicencePayload.objects.all()
+        self.assertEqual(licences.count(), 1)
+
+        run_number = 1
+        when = datetime.datetime(2022, 1, 1, 10, 11, 00)
+
+        filename, file_content = build_licence_data_file(licences, run_number, when)
+
+        self.assertEqual(filename, "CHIEF_LIVE_ILBDOTI_licenceData_1_202201011011")
+
+        self.maxDiff = None
+        expected_content = self.test_file.read_text()
+        self.assertEqual(expected_content, file_content)
+
+
 class TestBuildICMSLicenceDataFASILCancelPayload:
     @pytest.fixture(autouse=True)
     def _setup(self, db, fa_sil_revoke_payload) -> None:

--- a/mail/tests/files/icms/licence_data_files/fa_sil_individual_importer
+++ b/mail/tests/files/icms/licence_data_files/fa_sil_individual_importer
@@ -1,0 +1,8 @@
+1\fileHeader\ILBDOTI\CHIEF\licenceData\202201011011\1\N
+2\licence\IMA/2022/00003\insert\GBSIL3333333H\SIL\I\20220629\20241229
+3\trader\PR\\\\SIL Organisation\line_1\line_2\line_3\\\S227ZZ
+4\country\US\\O
+5\restrictions\Sample restrictions
+6\line\1\\\\\Sample goods description 1\Q\\030\\1\\\\\\
+7\end\licence\6
+8\fileTrailer\1

--- a/mail/tests/test_tasks.py
+++ b/mail/tests/test_tasks.py
@@ -587,7 +587,7 @@ def test_file_with_only_errors_raises_errors(db, caplog):
 class TestSendLicenceDataToHMRC:
     @pytest.fixture(autouse=True)
     def _setup(self, db):
-        ...
+        ...  # fmt: skip
 
     def test_task_is_called(self, caplog):
         tasks.send_licence_data_to_hmrc()
@@ -601,7 +601,7 @@ class TestSendLicenceDataToHMRC:
 class TestFakeLicenceReply:
     @pytest.fixture(autouse=True)
     def _setup(self, db):
-        ...
+        ...  # fmt: skip
 
     @override_settings(DEBUG=True, ICMS_FAKE_HMRC_REPLY=FakeChiefLicenceReplyEnum.ACCEPT)
     def test_task_is_called(self, caplog, capsys):


### PR DESCRIPTION
Individual importers can have an EORI of GBPR only. This needs to be handled by sending trader turn value of PR to HMRC