### PR TITLE
ECIL-647 Add Metric Carat as available option.

### DIFF
--- a/mail/enums.py
+++ b/mail/enums.py
@@ -98,7 +98,7 @@ class QuantityCodeEnum(IntegerChoices):
     KILOGRAMME = 23, "Kilogramme"
     # 100 kgs = 24, "100 kgs"
     # Tonne = 25, "Tonne"
-    # Metric Carat = 26, "Metric Carat"
+    METRIC_CARAT = 26, "Metric Carat"
     # 50 kgs = 27, "50 kgs"
 
     # 2. Gross weight


### PR DESCRIPTION
Change required as Metric Carat was fixed in ICMS to use the correct hmrc_code.